### PR TITLE
scenario / treeのボーダーが残るバグ修正

### DIFF
--- a/scenario-editer/javascript/file_tree.js
+++ b/scenario-editer/javascript/file_tree.js
@@ -258,6 +258,11 @@ function move_tree(element)
         }
         if(li.children[2].textContent == event.dataTransfer.getData('text'))
         {
+            let ul = document.getElementById("tree").children[0]
+            for(let i = 0; i < ul.childElementCount; i++)
+            {
+                ul.children[i].style.border = '';
+            }
             return
         }
         let index = get_data_index(Number(li.children[2].textContent))


### PR DESCRIPTION
ツリーをドラックし、自身にドロップすると選択時の枠が消えない問題を確認