### PR TITLE
scenario / 別のファイルを開こうとするとツリーが重なるバグ修正

### DIFF
--- a/scenario-editer/javascript/file_tree.js
+++ b/scenario-editer/javascript/file_tree.js
@@ -10,6 +10,7 @@ function import_file()
     document.getElementById("file-title").textContent = file_status[0]
     max_block_no = Number(file_status[1])
     let i = 1
+    data_array = []
     while(i < file_array.length)
     {
         let data = []


### PR DESCRIPTION
既にファイルを開いている状態で別のファイルを開こうとするとツリーが重なる問題を確認