### PR TITLE
scenario / 改行のバグを修正

### DIFF
--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -725,8 +725,9 @@ $(document).keydown(function(event){
                 let element = input_keybord.nextElementSibling
                 while(element != undefined)
                 {
-                    element_li.appendChild(element)
+                    const target = element
                     element = element.nextElementSibling
+                    element_li.appendChild(target)
                 }
                 input_keybord.blur()
 


### PR DESCRIPTION
改行の際に一部の要素を置いてけぼりにする問題を確認
原因の究明を行ったところ後ろ部分を1つしか継承できない作りになっていたのでそこを修正する
(コードミスである)