### PR TITLE
scenario / 文章をペーストしたときの問題を解決

### DIFF
--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -344,14 +344,18 @@ function edit_text()
         {
             if(!composition)
             {
+                // コピペなどでスペースを含む文章を渡された場合
+                // inputは改行をスペースとして受け取るのでやや不本意だがスペースを改行として考えて変換する
                 const datas = event.target.value.split(" ")
                 if(datas.length > 1)
                 {
+                    // 1行目入力
                     let element = make_label(datas[0])
                     copy_text_style(element, input_keybord)
                     event.target.before(element)
                     element = event.target.nextElementSibling
                     let element_li
+                    // 2行目以降は行作成　テキスト作成　改行作成
                     for(const data of datas.splice(1))
                     {
                         element_li = document.createElement("li")
@@ -373,6 +377,7 @@ function edit_text()
                         copy_text_style(element, input_keybord)
                         element_li.children[0].before(element)
                     }
+                    // インプットの内容を消して、終了し、最後に作った要素にカーソルを持ってくる
                     event.target.value = ""
                     input_keybord.blur()
                     element_li.click()

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -367,7 +367,6 @@ function edit_text()
                         {
                             const target = element
                             element = element.nextElementSibling
-                            console.log(target,element)
                             element_li.appendChild(target)
                         }
                         element_li.appendChild(document.createElement("br"))

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -347,7 +347,7 @@ function edit_text()
                 // コピペなどでスペースを含む文章を渡された場合
                 // inputは改行をスペースとして受け取るのでやや不本意だがスペースを改行として考えて変換する
                 const datas = event.target.value.split(" ")
-                if(datas.length > 1)
+                if(datas.length > 1 && event.target.value != " ")
                 {
                     // 1行目入力
                     let element = make_label(datas[0])

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -353,7 +353,7 @@ function edit_text()
                     let element = make_label(datas[0])
                     copy_text_style(element, input_keybord)
                     event.target.before(element)
-                    element = event.target.nextElementSibling
+                    element = event.target
                     let element_li
                     // 2行目以降は行作成　テキスト作成　改行作成
                     for(const data of datas.splice(1))
@@ -380,7 +380,12 @@ function edit_text()
                     // インプットの内容を消して、終了し、最後に作った要素にカーソルを持ってくる
                     event.target.value = ""
                     input_keybord.blur()
-                    element_li.click()
+
+                    select.setStart(element.firstChild, element.firstChild.length)
+                    select.setEnd(element.firstChild, element.firstChild.length)
+                    document.getSelection().removeAllRanges();
+                    document.getSelection().addRange(select);
+                    element.click()
                     return
                 }
 

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -344,6 +344,41 @@ function edit_text()
         {
             if(!composition)
             {
+                const datas = event.target.value.split(" ")
+                if(datas.length > 1)
+                {
+                    let element = make_label(datas[0])
+                    copy_text_style(element, input_keybord)
+                    event.target.before(element)
+                    element = event.target.nextElementSibling
+                    let element_li
+                    for(const data of datas.splice(1))
+                    {
+                        element_li = document.createElement("li")
+                        element_li.onclick = click_row_text
+                        element_li.classList.add("editor-row")
+                        element.parentElement.after(element_li)
+                        element = element.nextElementSibling
+                        while(element.tagName != "BR")
+                        {
+                            const target = element
+                            element = element.nextElementSibling
+                            console.log(target,element)
+                            element_li.appendChild(target)
+                        }
+                        element_li.appendChild(document.createElement("br"))
+                        synthesis_text(element_li.previousElementSibling)
+
+                        element = make_label(data)
+                        copy_text_style(element, input_keybord)
+                        element_li.children[0].before(element)
+                    }
+                    event.target.value = ""
+                    input_keybord.blur()
+                    element_li.click()
+                    return
+                }
+
                 // 変換前でないなら前のラベルに文字追加
                 if(event.target.previousElementSibling == null)
                 {


### PR DESCRIPTION
改行入りの文章をペーストしたときに改行がスペースに変わってしまう問題を解決する。
そもそもこの原因はinputは1行の文章を想定しているからである。
ゆえに少し曲がった直し方になるが後々textareaなどに変更して直せたらと思う