### PR TITLE
scenario / 前にラベルがない場合の右キーの問題を解消

### DIFF
--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -1083,6 +1083,13 @@ $(document).keydown(function(event){
                     index = 1
                     input_keybord.blur()
                 }
+                else if(destination == null)
+                {
+                    //前にラベルがない
+                    index = 1
+                    destination = input_keybord.nextElementSibling
+                    input_keybord.blur()
+                }
                 else if(destination.textContent == "")
                 {
                     // 行の最初


### PR DESCRIPTION
行の頭まで文字を削除し右に要素がある状態で右キーを押すとエラーが発生する。