### PR TITLE
scenario / inputからラベルを作成する時にスタイルを反映しないバグを修正

### DIFF
--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -400,6 +400,7 @@ function edit_text()
                     // ラベルがないなら作成する
                     let element = document.createElement("a")
                     element.onclick = edit_text
+                    copy_text_style(element, input_keybord)
                     input_keybord.before(element)
                 }
 


### PR DESCRIPTION
input内ののラベル作成時にスタイルをコピーしてない
削除後などで前にラベルがないとスタイルが反映されない