### PR TITLE
scenario / タグリストにundifinedが追加されてしまうバグ修正

### DIFF
--- a/scenario-editer/javascript/file_tree.js
+++ b/scenario-editer/javascript/file_tree.js
@@ -492,6 +492,10 @@ function make_text()
 
 function array_to_string(array, separator)
 {
+    if(array.length == 0)
+    {
+        return ""
+    }
     let string = ""
     string += array[0]
     i = 1


### PR DESCRIPTION
タグリストが空の状態で保存するとundifinedが追加されてしまうバグを確認
原因は配列をテキスト化している関数にあることが判明