### PR TITLE
scenario / テキストリンクの実装

### DIFF
--- a/scenario-editer/design.css
+++ b/scenario-editer/design.css
@@ -45,3 +45,25 @@ ul
     /* 行のどこに触れていてもカーソルがテキストモードになるように */
     cursor: text;
 }
+
+.link-window{
+    background-color: white;
+    width: 250px;
+    position: absolute;
+    border: solid 1px;
+    border-color: skyblue;
+    padding: 3px;
+}
+
+.link-window-title{
+    padding-left: 10px;
+    font-size: 18px;
+}
+
+.link-window-content{
+    font-size: 12px;
+    line-height: 1.5;
+    display: block;
+    overflow-wrap: break-word;
+    color: gray;
+}

--- a/scenario-editer/design.css
+++ b/scenario-editer/design.css
@@ -29,7 +29,7 @@ ul
 
 .editor-buttons
 {
-    margin-right: 10px;
+    margin-right: 15px;
 }
 
 .editor-input

--- a/scenario-editer/index.html
+++ b/scenario-editer/index.html
@@ -67,6 +67,11 @@
                                     <button id="button-font-mideum" class="btn btn-outline-success editor-button" type="button"><i class="fas fa-search"></i> M</button>
                                     <button id="button-font-bold" class="btn btn-outline-success editor-button" type="button"><i class="fas fa-search"></i> B</button>
                                 </div>
+                                <div  class="input-group editor-buttons" style="width:auto;">
+                                    <select class="form-select" aria-label="Default select example" id="select-text-link" style="width: 75px;"></select>
+                                    <button id="button-add-text-link" class="btn btn-outline-success editor-button" type="button"><i class="fas fa-search"></i> Add</button>
+                                    <button id="button-remove-text-link" class="btn btn-outline-success editor-button" type="button"><i class="fas fa-search"></i> Del</button>
+                                </div>
                             </div>
                         </div>
                         <div class="col-md-5">

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -2,6 +2,7 @@ let tag_list = []
 let selected = window.getSelection()
 let input_keybord = undefined
 let composition
+let link_window
 
 // ブロックタイトルの入力がされた
 document.getElementById("input-block-title").onchange = function()
@@ -315,6 +316,8 @@ function edit_text()
     {
         if(range.startContainer.parentElement.getAttribute("link") != null && event.ctrlKey == true)
         {
+            document.getElementById("editor-content").removeChild(link_window)
+            link_window = null
             select_brock(Number(range.startContainer.parentElement.getAttribute("link")))
             return
         }
@@ -648,6 +651,51 @@ function add_link(element, target)
     element.style.color = "blue"
     element.style.textDecoration = "underline"
     element.setAttribute("link", Number(target))
+    element.onmouseover = function(event)
+    {
+        event.target.style.backgroundColor = "skyblue"
+        make_link_window(event.target)
+    }
+    element.onmouseout = function(event)
+    {
+        event.target.style.backgroundColor = ""
+        document.getElementById("editor-content").removeChild(link_window)
+        link_window = null
+    }
+}
+
+function make_link_window(element)
+{
+    const rect = element.getBoundingClientRect()
+    const size = text_size(element)
+    const data = get_data(element.getAttribute("link"))
+    link_window = document.createElement("div")
+    link_window.style.left = String(rect.x + (size[0] / 2)) + "px"
+    link_window.style.top = String(rect.y + size[1]) + "px"
+    link_window.classList.add("link-window")
+    document.getElementById("editor-content").appendChild(link_window)
+    
+    let title = document.createElement("span")
+    title.textContent = data[3]
+    title.classList.add("link-window-title")
+    link_window.appendChild(title)
+    link_window.appendChild(document.createElement("br"))
+
+    let content = document.createElement("span")
+    content.textContent = ""
+    content.classList.add("link-window-content")
+    link_window.appendChild(content)
+    for(let i = 5; i < data.length && content.getBoundingClientRect().height <= 54; i++)
+    {
+        if(data[i].indexOf("<text") == 0)
+        {
+            content.textContent += data[i].slice(data[i].indexOf(">") + 1)
+        }
+    }
+    while(content.getBoundingClientRect().height > 54)
+    {
+        content.textContent = content.textContent.slice(0, content.textContent.length - 1)
+    }
 }
 
 function check_text_style(one, two)

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -271,6 +271,8 @@ function copy_text_style(one, two)
     // 現状扱うスタイル　(サイズ、太さ)
     one.style.fontSize = two.style.fontSize
     one.style.fontWeight = two.style.fontWeight
+    one.style.color = two.style.color
+    one.style.textDecoration = one.style.textDecoration
 }
 
 function text_size(element, select)

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -619,9 +619,20 @@ function make_label(str, styles)
             {
                 element_a.style.fontWeight = "bold"
             }
+            else if(style.indexOf("link=") == 0)
+            {
+                make_link(element_a, style.slice(style.indexOf("=") + 1))
+            }
         }
     }
     return element_a
+}
+
+function make_link(element, target)
+{
+    element.style.color = "blue"
+    element.style.textDecoration = "underline"
+    element.setAttribute("link", Number(target))
 }
 
 function synthesis_text(element_li)

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -621,14 +621,14 @@ function make_label(str, styles)
             }
             else if(style.indexOf("link=") == 0)
             {
-                make_link(element_a, style.slice(style.indexOf("=") + 1))
+                add_link(element_a, style.slice(style.indexOf("=") + 1))
             }
         }
     }
     return element_a
 }
 
-function make_link(element, target)
+function add_link(element, target)
 {
     element.style.color = "blue"
     element.style.textDecoration = "underline"

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -598,6 +598,11 @@ function export_data()
                 {
                     head += ",bold"
                 }
+                if(element.getAttribute("link") != null)
+                {
+                    head += ",link="
+                    head += element.getAttribute("link")
+                }
                 head += ">"
                 data.push(head + element.textContent)
             }

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -94,6 +94,23 @@ document.getElementById("button-font-bold").onclick = function()
     edit_select_text(function(element){element.style.fontWeight = "bold";});
 } 
 
+document.getElementById("button-add-text-link").onclick = function()
+{
+    edit_select_text(function(element){add_link(element, element.getAttribute("link"));});
+}
+
+document.getElementById("button-remove-text-link").onclick = function()
+{
+    edit_select_text(function(element)
+    {
+        element.style.color = ""
+        element.style.textDecoration = ""
+        element.removeAttribute("link")
+        element.onmouseover = function(){}
+        element.onmouseout = function(){}
+    })
+}
+
 
 function edit_select_text(func)
 {
@@ -644,6 +661,22 @@ function make_label(str, styles)
         }
     }
     return element_a
+}
+
+function reload_select_link()
+{
+    let select = document.getElementById("select-text-link")
+    while(select.firstChild)
+    {
+        select.removeChild(select.firstChild)
+    }
+    for(let i = 0; i < data_array.length; i++)
+    {
+        let option = document.createElement("option")
+        option.value = data_array[i][0]
+        option.text =  data_array[i][3]
+        select.appendChild(option)
+    }
 }
 
 function add_link(element, target)

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -635,6 +635,15 @@ function add_link(element, target)
     element.setAttribute("link", Number(target))
 }
 
+function check_text_style(one, two)
+{
+    if(one.style.fontSize != two.style.fontSize || one.style.fontWeight != two.style.fontWeight || one.getAttribute("link") != two.getAttribute("link"))
+    {
+        return false
+    }
+    return true
+}
+
 function synthesis_text(element_li)
 {
     // 行のコンテンツを1つずつ見て以下の処理
@@ -667,7 +676,7 @@ function synthesis_text(element_li)
                     i ++
                 }
             }
-            else if(last != -1 && element_li.children[last].style.fontSize == element_li.children[i].style.fontSize && element_li.children[last].style.fontWeight == element_li.children[i].style.fontWeight && element_li.children[last].style.color == element_li.children[i].style.color)
+            else if(last != -1 && check_text_style(element_li.children[last], element_li.children[i]))
             {
                 // 最後のラベルとスタイルが同じなら合成する
                 element_li.children[last].textContent += element_li.children[i].textContent

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -272,7 +272,7 @@ function copy_text_style(one, two)
     one.style.fontSize = two.style.fontSize
     one.style.fontWeight = two.style.fontWeight
     one.style.color = two.style.color
-    one.style.textDecoration = one.style.textDecoration
+    one.style.textDecoration = two.style.textDecoration
 }
 
 function text_size(element, select)

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -273,6 +273,10 @@ function copy_text_style(one, two)
     one.style.fontWeight = two.style.fontWeight
     one.style.color = two.style.color
     one.style.textDecoration = two.style.textDecoration
+    if(two.getAttribute("link") != null)
+    {
+        one.setAttribute("link", two.getAttribute("link"))
+    }
 }
 
 function text_size(element, select)

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -702,9 +702,21 @@ function make_link_window(element)
     const rect = element.getBoundingClientRect()
     const size = text_size(element)
     const data = get_data(element.getAttribute("link"))
+
+    let left = rect.x + (size[0] / 2)
+    let top = rect.y + size[1]
+    if(window.screen.width / 2 < left)
+    {
+        left -= 250
+    }
+    if(window.screen.height / 2 < top)
+    {
+        top -= (size[1] + 100)
+    }
+
     link_window = document.createElement("div")
-    link_window.style.left = String(rect.x + (size[0] / 2)) + "px"
-    link_window.style.top = String(rect.y + size[1]) + "px"
+    link_window.style.left = String(left) + "px"
+    link_window.style.top = String(top) + "px"
     link_window.classList.add("link-window")
     document.getElementById("editor-content").appendChild(link_window)
     

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -306,8 +306,14 @@ function edit_text()
 {
     // 選択部分の更新
     selected = window.getSelection();
+    range = selected.getRangeAt(0)
     if(selected.isCollapsed)
     {
+        if(range.startContainer.parentElement.getAttribute("link") != null && event.ctrlKey == true)
+        {
+            select_brock(Number(range.startContainer.parentElement.getAttribute("link")))
+            return
+        }
         // 範囲選択がされていない場合、入力状態へ
         // キーボード入力部の作成
         input_keybord = document.createElement("input")

--- a/scenario-editer/javascript/file_tree.js
+++ b/scenario-editer/javascript/file_tree.js
@@ -194,6 +194,7 @@ function make_tree()
         element_li.appendChild(block_no)
         tree.appendChild(element_li)
     }
+    reload_select_link()
 }
 
 function select_brock(block_no)

--- a/scenario-editer/javascript/file_tree.js
+++ b/scenario-editer/javascript/file_tree.js
@@ -183,12 +183,7 @@ function make_tree()
         
         // treeタイトルを押すと右のエディタに内容を表示する
         element_a.onclick = function(event){
-            save_data()
-            let own = event.target.parentElement
-            const block_no = Number(own.children[2].textContent)
-            select_block_no = block_no
-            const data = get_data(block_no)
-            import_data(data)
+            select_brock(Number(event.target.parentElement.children[2].textContent))
         }
 
         element_li.draggable = "true"
@@ -199,6 +194,13 @@ function make_tree()
         element_li.appendChild(block_no)
         tree.appendChild(element_li)
     }
+}
+
+function select_brock(block_no)
+{
+    save_data()
+    select_block_no = block_no
+    import_data(get_data(block_no))
 }
 
 function move_tree(element)


### PR DESCRIPTION
テキストにリンクを付与できるようにする
見た目を青色＋下線にし、マウスを乗せると情報を表示、Ctrlクリックでジャンプする。

①スタイルの追加　編集は出来ないがコピー等の時に下線と色を引き継ぐように
②テキストの読み込み時にリンクを受け取るように　→　スタイルを反映
③テストデータの用意
④ジャンプする関数を作成
⑤リンクをctrl + クリックでジャンプするように
⑥リンクの保存を実装
⑦カーソルを乗せるとジャンプ先を表示するように
⑧リンク編集用の追加ボタン、セレクトボックス、削除ボタンを作成
⑨リンクの編集関数を実装