### PR TITLE
scenario / 一定のリンクになってしまうバグ修正

### DIFF
--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -96,7 +96,7 @@ document.getElementById("button-font-bold").onclick = function()
 
 document.getElementById("button-add-text-link").onclick = function()
 {
-    edit_select_text(function(element){add_link(element, element.getAttribute("link"));});
+    edit_select_text(function(element){add_link(element, document.getElementById("select-text-link").value);});
 }
 
 document.getElementById("button-remove-text-link").onclick = function()


### PR DESCRIPTION
指定にかかわらず一定のリンクになってしまう問題が発生
原因はタグ追加の引数指定を間違えていること