### PR TITLE
scenario / ビューリンクの実装

### DIFF
--- a/scenario-editer/design.css
+++ b/scenario-editer/design.css
@@ -105,4 +105,5 @@ ul
     border-bottom: 1px gray solid;
     padding-top: 10px;
     padding-bottom: 10px;
+    margin-bottom: 30px;
 }

--- a/scenario-editer/design.css
+++ b/scenario-editer/design.css
@@ -73,6 +73,7 @@ ul
     color: black;
     text-decoration: none;
     cursor: pointer;
+    margin-right: 10px;
 }
 
 .lv-delete{
@@ -81,10 +82,17 @@ ul
     border-radius: 50%;
     border: 0;
     color: gray;
+    margin-left: 20px;
     margin-top: auto;
     margin-bottom: auto;
     font-size: 18px;
     text-align: center;
+}
+
+.lv-move{
+    border: 0;
+    height: 25px;
+    width: 30px;
 }
 
 .lv-input{

--- a/scenario-editer/design.css
+++ b/scenario-editer/design.css
@@ -67,3 +67,34 @@ ul
     overflow-wrap: break-word;
     color: gray;
 }
+
+.lv-title{
+    font-size: 22px;
+    color: black;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.lv-delete{
+    width: 25px;
+    height: 25px;
+    border-radius: 50%;
+    border: 0;
+    color: gray;
+    margin-top: auto;
+    margin-bottom: auto;
+    font-size: 18px;
+    text-align: center;
+}
+
+.lv-input{
+    width: 50px;
+    margin-left: 50px;
+}
+
+.lv-content{
+    border-top: 1px gray solid;
+    border-bottom: 1px gray solid;
+    padding-top: 10px;
+    padding-bottom: 10px;
+}

--- a/scenario-editer/index.html
+++ b/scenario-editer/index.html
@@ -71,6 +71,7 @@
                                     <select class="form-select" aria-label="Default select example" id="select-text-link" style="width: 75px;"></select>
                                     <button id="button-add-text-link" class="btn btn-outline-success editor-button" type="button"><i class="fas fa-search"></i> Add</button>
                                     <button id="button-remove-text-link" class="btn btn-outline-success editor-button" type="button"><i class="fas fa-search"></i> Del</button>
+                                    <button id="button-make-VL" class="btn btn-outline-success editor-button" type="button"><i class="fas fa-search"></i> VL</button>
                                 </div>
                             </div>
                         </div>

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -892,7 +892,19 @@ function make_view_link(link, open, lines)
                 {
                     event.target.parentElement.children[0].setAttribute("lines", event.target.value)
                     
-                    vl.removeChild(VL.children[VL.childElementCount - 1])
+                    let i = 0
+                    while(i < VL.childElementCount)
+                    {
+                        let element = VL.children[i]
+                        if(element.classList.contains("lv-content"))
+                        {
+                            VL.removeChild(element)
+                        }
+                        else
+                        {
+                            i++
+                        }
+                    }
                     let content = document.createElement("div")
                     content.classList.add("lv-content")
                     import_data_view(get_data(icon.getAttribute("link")), content, icon.getAttribute("lines"))
@@ -909,8 +921,23 @@ function make_view_link(link, open, lines)
         else if(icon.textContent == "∨")
         {
             icon.textContent = "＞"
-            VL.removeChild(VL.children[VL.childElementCount - 1])
-            VL.removeChild(VL.children[VL.childElementCount - 2])
+            let i = 0
+            while(i < VL.childElementCount)
+            {
+                let element = VL.children[i]
+                if(element.classList.contains("lv-content"))
+                {
+                    VL.removeChild(element)
+                }
+                else if(element.classList.contains("lv-input"))
+                {
+                    VL.removeChild(element)
+                }
+                else
+                {
+                    i++
+                }
+            }
         }
     }
     VL.appendChild(icon)

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -111,6 +111,12 @@ document.getElementById("button-remove-text-link").onclick = function()
     })
 }
 
+document.getElementById("button-make-VL").onclick = function()
+{
+    VL = make_view_link(document.getElementById("select-text-link").value, "false","A")
+    document.getElementById("editor-content-list").appendChild(VL)
+}
+
 
 function edit_select_text(func)
 {

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -657,7 +657,7 @@ function export_data()
             {
                 str += ",open=true"
             }
-            else if(element.getAttribute("lines") != null)
+            if(element.getAttribute("lines") != null)
             {
                 str += ",lines=" + element.getAttribute("lines")
             }
@@ -932,6 +932,10 @@ function make_view_link(link, open, lines)
     VL.appendChild(delete_button)
     VL.appendChild(document.createElement("br"))
 
+    if(open == "true")
+    {
+        icon.click()
+    }
     return VL
 }
 

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -649,31 +649,49 @@ function export_data()
     {
         synthesis_text(contents[i])
         let row = contents[i]
-        for(element of row.children)
+        let element = row.children[0]
+        if(element.tagName == "A" && element.classList.contains("lv-title"))
         {
-            if(element.tagName == "A")
+            let str = "<VL,link=" + element.getAttribute("link")
+            if(element.textContent != "＞")
             {
-                let head = "<text"
-                if(element.style.fontSize != "")
-                {
-                    head += ",size="
-                    head += element.style.fontSize
-                }
-                if(element.style.fontWeight == "bold")
-                {
-                    head += ",bold"
-                }
-                if(element.getAttribute("link") != null)
-                {
-                    head += ",link="
-                    head += element.getAttribute("link")
-                }
-                head += ">"
-                data.push(head + element.textContent)
+                str += ",open=true"
             }
-            else if(element.tagName == "BR")
+            else if(element.getAttribute("lines") != null)
             {
-                data.push("<break>")
+                str += ",lines=" + element.getAttribute("lines")
+            }
+            str += ">"
+            data.push(str)
+        }
+        else
+        {
+            for(element of row.children)
+            {
+                if(element.tagName == "A")
+                {
+                    let head = "<text"
+                    if(element.style.fontSize != "")
+                    {
+                        head += ",size="
+                        head += element.style.fontSize
+                    }
+                    if(element.style.fontWeight == "bold")
+                    {
+                        head += ",bold"
+                    }
+                    if(element.getAttribute("link") != null)
+                    {
+                        head += ",link="
+                        head += element.getAttribute("link")
+                    }
+                    head += ">"
+                    data.push(head + element.textContent)
+                }
+                else if(element.tagName == "BR")
+                {
+                    data.push("<break>")
+                }
             }
         }
     }

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -854,7 +854,7 @@ function make_view_link(link, open, lines)
     let VL = document.createElement("li")
     let icon = document.createElement("a")
     icon.textContent = "＞"
-    icon.fontSize = "18px"
+    icon.classList.add("lv-title")
     icon.setAttribute("link",link)
     icon.setAttribute("lines",lines)
     icon.onclick = function(event)
@@ -866,6 +866,7 @@ function make_view_link(link, open, lines)
             icon.textContent = "∨"
             let input_lines = document.createElement("input")
             input_lines.value = icon.getAttribute("lines")
+            input_lines.classList.add("lv-input")
             input_lines.onchange = function(event)
             {
                 let vl = event.target.parentElement
@@ -875,6 +876,7 @@ function make_view_link(link, open, lines)
                     
                     vl.removeChild(VL.children[VL.childElementCount - 1])
                     let content = document.createElement("div")
+                    content.classList.add("lv-content")
                     import_data_view(get_data(icon.getAttribute("link")), content, icon.getAttribute("lines"))
                     vl.appendChild(content)
                 }
@@ -882,6 +884,7 @@ function make_view_link(link, open, lines)
             VL.children[VL.childElementCount - 1].before(input_lines)          
 
             let content = document.createElement("div")
+            content.classList.add("lv-content")
             import_data_view(get_data(icon.getAttribute("link")), content, icon.getAttribute("lines"))
             VL.appendChild(content)
         }
@@ -896,12 +899,13 @@ function make_view_link(link, open, lines)
 
     let title = document.createElement("a")
     title.textContent = data[3]
-    title.fontSize = "18px"
+    title.classList.add("lv-title")
     title.onclick = function(){select_brock(link);}
     VL.appendChild(title)
 
     let delete_button = document.createElement("button")
     delete_button.textContent = "×"
+    delete_button.classList.add("lv-delete")
     delete_button.onclick = function(event)
     {
         let vl = event.target.parentElement

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -585,6 +585,40 @@ function import_data(data)
             element_li.onclick = click_row_text
             element_li.classList.add("editor-row")
         }
+        else if(status[0] == "VL")
+        {
+            let link = null
+            let open = false
+            let lines = "A"
+            for(let style of status.slice(1))
+            {
+                if(style.indexOf("link=") == 0)
+                {
+                    link = Number(style.slice(style.indexOf("=") + 1))
+                }
+                else if(style.indexOf("open=") == 0)
+                {
+                    link = style.slice(style.indexOf("=") + 1)
+                }
+                else if(style.indexOf("lines=") == 0)
+                {
+                    link = style.slice(style.indexOf("=") + 1)
+                }
+            }
+            if(link != null)
+            {
+                if(element_li.childElementCount != 0)
+                {
+                    const element_br = document.createElement("br")
+                    element_li.appendChild(element_br)
+                    editor_content_list.appendChild(element_li)
+                    element_li = document.createElement("li")
+                    element_li.onclick = click_row_text
+                    element_li.classList.add("editor-row")
+                }
+                editor_content_list.appendChild(make_view_link(link, open, lines))
+            }
+        }
         i++;
     }
 
@@ -842,7 +876,7 @@ function make_view_link(link, open, lines)
     VL.appendChild(delete_button)
     VL.appendChild(document.createElement("br"))
 
-    document.getElementById("editor-content").appendChild(VL)
+    return VL
 }
 
 function check_text_style(one, two)

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -646,6 +646,46 @@ function export_data()
     return data
 }
 
+function import_data_view(data, parent)
+{
+    for(const info of data.slice(5))
+    {
+        if(info[0] != "<")
+        {
+            continue
+        }
+        const status = info.slice(1, info.indexOf(">")).split(",")
+        const content = info.slice(info.indexOf(">") + 1)
+
+        if(status == "text")
+        {
+            let text = document.createElement("a")
+            text.textContent = content
+            for(let style of status.slice(1))
+            {
+                if(style.indexOf("size=") == 0)
+                {
+                    text.style.fontSize = style.slice(style.indexOf("=") + 1)
+                }
+                else if(style == "bold")
+                {
+                    text.style.fontWeight = "bold"
+                }
+                else if(style.indexOf("link=") == 0)
+                {
+                    add_link(text, style.slice(style.indexOf("=") + 1))
+                    text.onclick = function(event){select_brock(event.target.getAttribute("link"));}
+                }
+            }
+            parent.appendChild(text)
+        }
+        if(status == "break")
+        {
+            parent.appendChild(document.createElement("br"))
+        }
+    }
+}
+
 function make_label(str, styles)
 {
     // 文字とスタイルを入れるとテキストを作成する
@@ -752,6 +792,57 @@ function make_link_window(element)
     {
         content.textContent = content.textContent.slice(0, content.textContent.length - 1)
     }
+}
+
+function make_view_link(link, open, lines)
+{
+    const data = get_data(link)
+    if(data == false)
+    {
+        return
+    }
+
+    let VL = document.createElement("li")
+    let icon = document.createElement("a")
+    icon.textContent = "＞"
+    icon.fontSize = "18px"
+    icon.setAttribute("link",link)
+    icon.onclick = function(event)
+    {
+        let icon = event.target
+        let VL = icon.parentElement
+        if(icon.textContent == "＞")
+        {
+            icon.textContent = "∨"
+            let content = document.createElement("div")
+            import_data_view(get_data(icon.getAttribute("link")), content)
+            VL.appendChild(content)
+        }
+        else if(icon.textContent == "∨")
+        {
+            icon.textContent = "＞"
+            VL.removeChild(VL.children[VL.childElementCount - 1])
+        }
+    }
+    VL.appendChild(icon)
+
+    let title = document.createElement("a")
+    title.textContent = data[3]
+    title.fontSize = "18px"
+    title.onclick = function(){select_brock(link);}
+    VL.appendChild(title)
+
+    let delete_button = document.createElement("button")
+    delete_button.textContent = "×"
+    delete_button.onclick = function(event)
+    {
+        let vl = event.target.parentElement
+        vl.parentElement.removeChild(vl)
+    }
+    VL.appendChild(delete_button)
+    VL.appendChild(document.createElement("br"))
+
+    document.getElementById("editor-content").appendChild(VL)
 }
 
 function check_text_style(one, two)

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -948,6 +948,30 @@ function make_view_link(link, open, lines)
     title.onclick = function(){select_brock(link);}
     VL.appendChild(title)
 
+    let up_button = document.createElement("button")
+    up_button.textContent = "∧"
+    up_button.onclick = function(event)
+    {
+        let vl = event.target.parentElement
+        if(vl.previousElementSibling != null)
+        {
+            vl.previousElementSibling.before(vl)
+        }
+    }
+    VL.appendChild(up_button)
+
+    let down_button = document.createElement("button")
+    down_button.textContent = "∨"
+    down_button.onclick = function(event)
+    {
+        let vl = event.target.parentElement
+        if(vl.nextElementSibling != null)
+        {
+            vl.nextElementSibling.after(vl)
+        }
+    }
+    VL.appendChild(down_button)
+
     let delete_button = document.createElement("button")
     delete_button.textContent = "×"
     delete_button.classList.add("lv-delete")

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -598,11 +598,11 @@ function import_data(data)
                 }
                 else if(style.indexOf("open=") == 0)
                 {
-                    link = style.slice(style.indexOf("=") + 1)
+                    open = style.slice(style.indexOf("=") + 1)
                 }
                 else if(style.indexOf("lines=") == 0)
                 {
-                    link = style.slice(style.indexOf("=") + 1)
+                    lines = style.slice(style.indexOf("=") + 1)
                 }
             }
             if(link != null)

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -950,6 +950,7 @@ function make_view_link(link, open, lines)
 
     let up_button = document.createElement("button")
     up_button.textContent = "∧"
+    up_button.classList.add("lv-move")
     up_button.onclick = function(event)
     {
         let vl = event.target.parentElement
@@ -962,6 +963,7 @@ function make_view_link(link, open, lines)
 
     let down_button = document.createElement("button")
     down_button.textContent = "∨"
+    down_button.classList.add("lv-move")
     down_button.onclick = function(event)
     {
         let vl = event.target.parentElement

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -680,8 +680,18 @@ function export_data()
     return data
 }
 
-function import_data_view(data, parent)
+function import_data_view(data, parent, lines)
 {
+    if(lines == null)
+    {
+        lines = "A"
+    }
+    else if(lines != "A")
+    {
+        lines = Number(lines)
+    }
+
+    line_ct = 0
     for(const info of data.slice(5))
     {
         if(info[0] != "<")
@@ -716,6 +726,11 @@ function import_data_view(data, parent)
         if(status == "break")
         {
             parent.appendChild(document.createElement("br"))
+            line_ct ++
+            if(lines != "A" && line_ct >= lines)
+            {
+                break
+            }
         }
     }
 }
@@ -841,6 +856,7 @@ function make_view_link(link, open, lines)
     icon.textContent = "＞"
     icon.fontSize = "18px"
     icon.setAttribute("link",link)
+    icon.setAttribute("lines",lines)
     icon.onclick = function(event)
     {
         let icon = event.target
@@ -848,14 +864,32 @@ function make_view_link(link, open, lines)
         if(icon.textContent == "＞")
         {
             icon.textContent = "∨"
+            let input_lines = document.createElement("input")
+            input_lines.value = icon.getAttribute("lines")
+            input_lines.onchange = function(event)
+            {
+                let vl = event.target.parentElement
+                if(event.target.value == "A" || !isNaN(event.target.value))
+                {
+                    event.target.parentElement.children[0].setAttribute("lines", event.target.value)
+                    
+                    vl.removeChild(VL.children[VL.childElementCount - 1])
+                    let content = document.createElement("div")
+                    import_data_view(get_data(icon.getAttribute("link")), content, icon.getAttribute("lines"))
+                    vl.appendChild(content)
+                }
+            }
+            VL.children[VL.childElementCount - 1].before(input_lines)          
+
             let content = document.createElement("div")
-            import_data_view(get_data(icon.getAttribute("link")), content)
+            import_data_view(get_data(icon.getAttribute("link")), content, icon.getAttribute("lines"))
             VL.appendChild(content)
         }
         else if(icon.textContent == "∨")
         {
             icon.textContent = "＞"
             VL.removeChild(VL.children[VL.childElementCount - 1])
+            VL.removeChild(VL.children[VL.childElementCount - 2])
         }
     }
     VL.appendChild(icon)


### PR DESCRIPTION
指定されたブロックの中身を表示し、リンクとしても動作するアイテムを作成する。

＜アイテム内容物＞
折り畳みボタン　ツリーの子要素のように内容表示のオンオフを切り替えれる
タイトル　　　　ブロック名　リンクになっていてこれは通常クリックでもジャンプする
移動ボタン　　　上下に行ごと移動する
削除ボタン　　　この要素を削除するためのボタン
行数指定　　　インプットで行数を受け取る　Aと入れると全行を表示する
内容表示　　　指定された行数内容を表示する。