### PR TITLE
scenario / タグリストに空白がタグとして追加されるバグの修正

### DIFF
--- a/scenario-editer/javascript/file_tree.js
+++ b/scenario-editer/javascript/file_tree.js
@@ -24,7 +24,14 @@ function import_file()
         data.push(data_status[3])
         // タグリスト
         i++
-        data.push(file_array[i].split(","))
+        if(file_array[i] == "")
+        {
+            data.push([])
+        }
+        else
+        {
+            data.push(file_array[i].split(","))
+        }
         // コンテンツ
         i++
         while( i < file_array.length && file_array[i][0] == "<")


### PR DESCRIPTION
タグリストに空の文字列がタグとして発生する問題を修正する

・原因
ファイルのインポート時に発生している。
splitの仕様理解していなかった。splitに空の文字列を渡すと空の配列ではなく空の文字列1つが入った配列を返す。
そのためタグリストが空の時からの文字列をタグとしてしまう