### PR TITLE
scenario / 半角スペースが反映されないバグ

### DIFF
--- a/scenario-editer/design.css
+++ b/scenario-editer/design.css
@@ -56,6 +56,10 @@ ul
     cursor: text;
 }
 
+.editor-row-text > a{
+    white-space: pre;
+}
+
 .link-window{
     background-color: white;
     width: 250px;


### PR DESCRIPTION
半角スペースがなくなってしまう問題

ラベルの仕様的に半角スペースは１つまでしか書けないので
大きな変更になりかねないのでいくつかの方法をやってみるように