### PR TITLE
scenario / inputの高さを調整

### DIFF
--- a/scenario-editer/design.css
+++ b/scenario-editer/design.css
@@ -49,6 +49,7 @@ ul
     outline: none;
     /* 入力中でも文が自然になるように */
     margin-right: -3px;
+    padding: 0;
 }
 
 .editor-row-text{


### PR DESCRIPTION
inputの高さがフォントサイズが同じラベルよりも大きくなる問題
以前から放置していたので解決する

原因を確認したところinputに最初からpaddingがあるためだと判明