### PR TITLE
scenario / 全選択後に一部操作が反応しない問題を解決

### DIFF
--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -1253,13 +1253,21 @@ $(document).keydown(function(event){
         }
 
         let end = editor
+        let end_node = 0
         while(end.children[end.childElementCount - 1] != null)
         {
             end = end.children[end.childElementCount - 1]
         }
-        if(end.lastChild != null)
+        console.log(end.previousElementSibling)
+        if(end.previousElementSibling != null && end.previousElementSibling.tagName == "A")
         {
-            end = end.lastChild
+            end = end.previousElementSibling
+        }
+        
+        if(end.firstChild != null)
+        {
+            end = end.firstChild
+            end_node = end.length
         }
         else
         {
@@ -1267,7 +1275,7 @@ $(document).keydown(function(event){
         }
 
         select.setStart(start, start_node)
-        select.setEnd(end, 0)
+        select.setEnd(end, end_node)
         document.getSelection().removeAllRanges();
         document.getSelection().addRange(select);
         event.keyCode = null;

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -1237,6 +1237,7 @@ $(document).keydown(function(event){
         let editor = document.getElementById("editor-content-list")
 
         let start = editor
+        let start_node = 0
         while(start.children[0] != null)
         {
             start = start.children[0]
@@ -1244,6 +1245,11 @@ $(document).keydown(function(event){
         if(start.firstChild != null)
         {
             start = start.firstChild
+        }
+        else
+        {
+            start = start.parentElement
+            start_node = 1
         }
 
         let end = editor
@@ -1255,10 +1261,14 @@ $(document).keydown(function(event){
         {
             end = end.lastChild
         }
+        else
+        {
+            end = end.parentElement
+        }
 
         console.log(start)
         console.log(end)
-        select.setStart(start, 0)
+        select.setStart(start, start_node)
         select.setEnd(end, 0)
         document.getSelection().removeAllRanges();
         document.getSelection().addRange(select);

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -1233,6 +1233,10 @@ $(document).keydown(function(event){
     {
         // 全選択
         console.log("A")
+        if(input_keybord != undefined)
+        {
+            input_keybord.blur()
+        }
         let select = new Range();
         let editor = document.getElementById("editor-content-list")
 

--- a/scenario-editer/javascript/editor.js
+++ b/scenario-editer/javascript/editor.js
@@ -1266,8 +1266,6 @@ $(document).keydown(function(event){
             end = end.parentElement
         }
 
-        console.log(start)
-        console.log(end)
         select.setStart(start, start_node)
         select.setEnd(end, 0)
         document.getSelection().removeAllRanges();


### PR DESCRIPTION
・症状
全選択からの切り取りが機能していない
貼り付けも、全選択の選択位置の問題か。

・原因
全選択時のカーソルの位置が適切ではない
＜本来あるべき位置＞
①テキストがある場合　右　テキストの適した位地
②テキストがない場合　行(li)(前なら1　後ろなら0)